### PR TITLE
Migrate to null safety

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -56,7 +56,7 @@ packages:
       name: cupertino_icons
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "1.0.3"
   fake_async:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,13 +3,13 @@ description: Demonstrates how to use the bordered_text plugin.
 publish_to: 'none'
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   flutter:
     sdk: flutter
 
-  cupertino_icons: ^0.1.2
+  cupertino_icons: ^1.0.3
 
 dev_dependencies:
   flutter_test:

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -5,11 +5,9 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
+import 'package:bordered_text_example/main.dart' show MyApp;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
-import 'package:bordered_text_example/main.dart' show MyApp;
-
 
 void main() {
   testWidgets('BorderedText has a stroke that matches the text',
@@ -28,10 +26,9 @@ void main() {
     final textFinder = find.text('M');
     final stroke = textFinder.first;
 
-    final stackParent =
-        find.descendant(of: find.byType(Stack), matching: stroke);
+    final stackParent = find.ancestor(of: stroke, matching: find.byType(Stack));
     final stackChildren =
-        find.ancestor(of: stroke, matching: find.byType(Stack));
+        find.descendant(of: stackParent, matching: find.text('M'));
 
     expect(stackParent, findsOneWidget);
     expect(stackChildren, findsNWidgets(2));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: bordered_text
-description: Flutter plugin for applying subtle stroke to a Text widget. Supports Android and iOS.
+description: Flutter plugin for applying subtle stroke to a Text widget. Supports Android, iOS, and Web.
 version: 2.0.0
 homepage: https://github.com/tewshi/bordered-text
 


### PR DESCRIPTION
This PR moves all content to support null-safety, for both package and example.